### PR TITLE
Fixed unneeded spaces in cleansed text

### DIFF
--- a/scrapy_llm/handler.py
+++ b/scrapy_llm/handler.py
@@ -6,7 +6,6 @@ from scrapy import Request, signals
 from scrapy.crawler import Crawler
 from scrapy.http.response import Response
 from scrapy.spiders import Spider
-from scrapy.utils.log import logger
 
 from scrapy_llm.config import LLM_EXTRACTED_DATA_KEY, LlmExtractorConfig
 from scrapy_llm.types import LLMOutput, T
@@ -23,7 +22,6 @@ class LlmExtractorMiddleware(Generic[T]):
     ):
         self.crawler = crawler
         self.config = config
-        self.logger = logger
 
     @classmethod
     def from_crawler(cls: Type[LLMExtractor], crawler: Crawler) -> LLMExtractor:
@@ -58,15 +56,6 @@ class LlmExtractorMiddleware(Generic[T]):
 
         cl = instructor.from_litellm(completion)
 
-        self.logger.debug(f"Raw HTML: {raw_html}")
-        content = process_html(
-            raw_html,
-            self.config.html_cleaner_ignore_links,
-            self.config.html_cleaner_ignore_images
-        )
-
-        self.logger.debug(f"Content: {content}")
-
         resp: List[response_model] = cl.chat.completions.create(
             model=self.config.llm_model,
             api_base=self.config.llm_api_base,
@@ -79,7 +68,11 @@ class LlmExtractorMiddleware(Generic[T]):
                 },
                 {
                     "role": "user",
-                    "content": content
+                    "content": process_html(
+                        raw_html,
+                        self.config.html_cleaner_ignore_links,
+                        self.config.html_cleaner_ignore_images
+                    )
                 }
             ],
             # always return an iterable of the given type to simplify nested type cascading.

--- a/scrapy_llm/utils.py
+++ b/scrapy_llm/utils.py
@@ -24,7 +24,7 @@ def process_html(
     cleaner.ignore_links = ignore_links
     cleaner.ignore_images = ignore_images
     clean_content = cleaner.handle(html)
-    return " ".join(clean_content)
+    return clean_content
 
 
 def flatten_dict(items: T) -> CombinedLLMOutput:


### PR DESCRIPTION
I thought it would be useful to have access to the Scrapy logger even when the spider object is not on hand. Also I wanted to examine the raw and processed HTML that I am getting so I added debug logs for that.

Not really related by why are you adding spaces between all the characters returned by `html2text`? Was that really your intention? If so I can remove the change in `utils.py` from the PR, but it makes it really hard to read the cleaned HTML text and IMO probably doubles the number of tokens being passed to the LLM (and hence the cost).