### PR TITLE
Base url support

### DIFF
--- a/README.md
+++ b/README.md
@@ -278,12 +278,28 @@ LLM_MODEL_TEMPERATURE = 0.0001
 
 - type: str
 - required: False
-- default: You are a data extraction expert, your role is to extract data from the given text according to the provided schema. make sure your output is a valid JSON object.
+- default: You are a data extraction expert, your role is to extract data from the given text according to the provided schema. Make sure your output is a valid JSON object. 
+You are crawling the following URL: {url}
 
-the system message to use for the language model.
+the system message to use for the language model. Use the `{url}` placeholder to include the URL of the webpage being scraped.
 
 ```python
 LLM_SYSTEM_MESSAGE = '...'
+```
+
+### `LLM_ADDITIONAL_SYSTEM_MESSAGES`
+
+- type: dict[str, str]
+- required: False
+- default: {}
+
+additional system messages appended to the default system message. Use "_base" as the key to add a message that will be used for all response models. Use the name of the response model as the key to add a message that will be used for a specific response model.
+
+```python
+LLM_ADDITIONAL_SYSTEM_MESSAGES = {
+    "_base": "...",
+    "ResponseModel": "..."
+}
 ```
 
 ### `HTML_CLEANER_IGNORE_LINKS`

--- a/README.md
+++ b/README.md
@@ -287,19 +287,16 @@ the system message to use for the language model. Use the `{url}` placeholder to
 LLM_SYSTEM_MESSAGE = '...'
 ```
 
-### `LLM_ADDITIONAL_SYSTEM_MESSAGES`
+### `LLM_ADDITIONAL_SYSTEM_MESSAGE`
 
-- type: dict[str, str]
+- type: str
 - required: False
-- default: {}
+- default: ""
 
-additional system messages appended to the default system message. Use "_base" as the key to add a message that will be used for all response models. Use the name of the response model as the key to add a message that will be used for a specific response model.
+the additional system message is appended to the default system message.
 
 ```python
-LLM_ADDITIONAL_SYSTEM_MESSAGES = {
-    "_base": "...",
-    "ResponseModel": "..."
-}
+LLM_ADDITIONAL_SYSTEM_MESSAGE = "..."
 ```
 
 ### `HTML_CLEANER_IGNORE_LINKS`

--- a/scrapy_llm/config.py
+++ b/scrapy_llm/config.py
@@ -18,7 +18,11 @@ class LlmExtractorConfig:
     llm_model: str = "gpt-4-turbo"
     llm_temperature: float = 0.0001
     llm_system_message: str = (
-        "You are a data extraction expert, your role is to extract data from the given text according to the provided schema. make sure your output is a valid JSON object."
+        """"
+        You are a data extraction expert, your role is to extract data from the given text according to the provided schema. make sure your output is a valid JSON object.
+
+        If you find relative URLs in the source, turn them into absolute URLs.
+        """
     )
     html_cleaner_ignore_links: bool = True
     html_cleaner_ignore_images: bool = True

--- a/scrapy_llm/config.py
+++ b/scrapy_llm/config.py
@@ -1,5 +1,5 @@
 import importlib
-from dataclasses import dataclass, field
+from dataclasses import dataclass
 from typing import Final, Optional, Type
 
 from scrapy.crawler import Crawler
@@ -21,7 +21,7 @@ class LlmExtractorConfig:
         "You are a data extraction expert, your role is to extract data from the given text according to the provided schema. Make sure your output is a valid JSON object. "
         "You are crawling the following URL: {url}"
     )
-    llm_additional_system_messages: dict[str, str] = field(default_factory=dict)
+    llm_additional_system_message: str = ""
     html_cleaner_ignore_links: bool = True
     html_cleaner_ignore_images: bool = True
 
@@ -31,8 +31,8 @@ class LlmExtractorConfig:
         system_message: str = crawler.settings.get(
             "LLM_SYSTEM_MESSAGE", cls.llm_system_message
         )
-        additional_system_messages: dict[str, str] = crawler.settings.get(
-            "LLM_ADDITIONAL_SYSTEM_MESSAGES", {}
+        additional_system_message: str = crawler.settings.get(
+            "LLM_ADDITIONAL_SYSTEM_MESSAGE", ""
         )
         model: str = crawler.settings.get("LLM_MODEL", cls.llm_model)
         model_temperature: float = crawler.settings.get(
@@ -65,7 +65,7 @@ class LlmExtractorConfig:
             llm_model=model,
             llm_temperature=model_temperature,
             llm_system_message=system_message,
-            llm_additional_system_messages=additional_system_messages,
+            llm_additional_system_message=additional_system_message,
             html_cleaner_ignore_links=html_cleaner_ignore_links,
             html_cleaner_ignore_images=html_cleaner_ignore_images,
         )

--- a/scrapy_llm/config.py
+++ b/scrapy_llm/config.py
@@ -1,5 +1,5 @@
 import importlib
-from dataclasses import dataclass
+from dataclasses import dataclass, field
 from typing import Final, Optional, Type
 
 from scrapy.crawler import Crawler
@@ -19,9 +19,9 @@ class LlmExtractorConfig:
     llm_temperature: float = 0.0001
     llm_system_message: str = (
         "You are a data extraction expert, your role is to extract data from the given text according to the provided schema. Make sure your output is a valid JSON object. "
-        "You are crawling the following URL: "
+        "You are crawling the following URL: {url}"
     )
-    llm_additional_system_message: str = ""
+    llm_additional_system_messages: dict[str, str] = field(default_factory=dict)
     html_cleaner_ignore_links: bool = True
     html_cleaner_ignore_images: bool = True
 
@@ -31,8 +31,8 @@ class LlmExtractorConfig:
         system_message: str = crawler.settings.get(
             "LLM_SYSTEM_MESSAGE", cls.llm_system_message
         )
-        additional_system_message: str = crawler.settings.get(
-            "LLM_ADDITIONAL_SYSTEM_MESSAGE", ""
+        additional_system_messages: dict[str, str] = crawler.settings.get(
+            "LLM_ADDITIONAL_SYSTEM_MESSAGES", {}
         )
         model: str = crawler.settings.get("LLM_MODEL", cls.llm_model)
         model_temperature: float = crawler.settings.get(
@@ -65,7 +65,7 @@ class LlmExtractorConfig:
             llm_model=model,
             llm_temperature=model_temperature,
             llm_system_message=system_message,
-            llm_additional_system_message=additional_system_message,
+            llm_additional_system_messages=additional_system_messages,
             html_cleaner_ignore_links=html_cleaner_ignore_links,
             html_cleaner_ignore_images=html_cleaner_ignore_images,
         )

--- a/scrapy_llm/config.py
+++ b/scrapy_llm/config.py
@@ -18,12 +18,10 @@ class LlmExtractorConfig:
     llm_model: str = "gpt-4-turbo"
     llm_temperature: float = 0.0001
     llm_system_message: str = (
-        """"
-        You are a data extraction expert, your role is to extract data from the given text according to the provided schema. make sure your output is a valid JSON object.
-
-        If you find relative URLs in the source, turn them into absolute URLs.
-        """
+        "You are a data extraction expert, your role is to extract data from the given text according to the provided schema. Make sure your output is a valid JSON object. "
+        "You are crawling the following URL: "
     )
+    llm_additional_system_message: str = ""
     html_cleaner_ignore_links: bool = True
     html_cleaner_ignore_images: bool = True
 
@@ -32,6 +30,9 @@ class LlmExtractorConfig:
         api_base: str = crawler.settings.get("LLM_API_BASE", cls.llm_api_base)
         system_message: str = crawler.settings.get(
             "LLM_SYSTEM_MESSAGE", cls.llm_system_message
+        )
+        additional_system_message: str = crawler.settings.get(
+            "LLM_ADDITIONAL_SYSTEM_MESSAGE", ""
         )
         model: str = crawler.settings.get("LLM_MODEL", cls.llm_model)
         model_temperature: float = crawler.settings.get(
@@ -64,6 +65,7 @@ class LlmExtractorConfig:
             llm_model=model,
             llm_temperature=model_temperature,
             llm_system_message=system_message,
+            llm_additional_system_message=additional_system_message,
             html_cleaner_ignore_links=html_cleaner_ignore_links,
             html_cleaner_ignore_images=html_cleaner_ignore_images,
         )

--- a/scrapy_llm/handler.py
+++ b/scrapy_llm/handler.py
@@ -45,7 +45,7 @@ class LlmExtractorMiddleware(Generic[T]):
             )
 
         extracted_data = self.extract_item_data(
-            response.text, response_model
+            request.url, response.text, response_model
         )
 
         if self.config.unwrap_nested:
@@ -60,6 +60,7 @@ class LlmExtractorMiddleware(Generic[T]):
 
     def extract_item_data(
         self,
+        base_url: str,
         raw_html: str,
         response_model: Type[T],
     ) -> List[LLMOutput]:
@@ -75,7 +76,7 @@ class LlmExtractorMiddleware(Generic[T]):
             messages=[
                 {
                     "role": "system",
-                    "content": self.config.llm_system_message,
+                    "content": self.config.llm_system_message + " " + f"The base URL is {base_url}",
                 },
                 {
                     "role": "user",

--- a/scrapy_llm/handler.py
+++ b/scrapy_llm/handler.py
@@ -68,11 +68,7 @@ class LlmExtractorMiddleware(Generic[T]):
 
         cl = instructor.from_litellm(completion)
 
-        system_message = f"""
-            {self.config.llm_system_message.format(url=url)} 
-            {self.config.llm_additional_system_messages.get("_base", "")} 
-            {self.config.llm_additional_system_messages.get(response_model.__name__, "")}
-        """
+        system_message = f"{self.config.llm_system_message.format(url=url)} {self.config.llm_additional_system_message}"
 
         resp: List[response_model] = cl.chat.completions.create(
             model=self.config.llm_model,

--- a/scrapy_llm/handler.py
+++ b/scrapy_llm/handler.py
@@ -64,11 +64,15 @@ class LlmExtractorMiddleware(Generic[T]):
         response_model: Type[T],
         url: str,
     ) -> List[LLMOutput]:
-        """Extract dorm data from the given HTML text using an LLM model."""
+        """Extract data from the given HTML text using an LLM model."""
 
         cl = instructor.from_litellm(completion)
 
-        system_message = f"{self.config.llm_system_message}{url} {self.config.llm_additional_system_message}"
+        system_message = f"""
+            {self.config.llm_system_message.format(url=url)} 
+            {self.config.llm_additional_system_messages.get("_base", "")} 
+            {self.config.llm_additional_system_messages.get(response_model.__name__, "")}
+        """
 
         resp: List[response_model] = cl.chat.completions.create(
             model=self.config.llm_model,


### PR DESCRIPTION
I'm scraping a site that has relative URLs, and Pydantic was reporting validation errors for `HttpUrl` (which I got from `pydantic-string-url` so it's serializable).

This fixes the problem by getting the LLM to resolve the URLs.